### PR TITLE
Add config option to move buttons to monitor

### DIFF
--- a/MonitorDoorButtons/Patches/StartOfRoundPatch.cs
+++ b/MonitorDoorButtons/Patches/StartOfRoundPatch.cs
@@ -5,7 +5,6 @@ using TMPro;
 using GameNetcodeStuff;
 
 using MonitorDoorButtons.Utilities;
-using System.Collections.Generic;
 using System.Collections;
 
 namespace MonitorDoorButtons.Patches

--- a/MonitorDoorButtons/Patches/StartOfRoundPatch.cs
+++ b/MonitorDoorButtons/Patches/StartOfRoundPatch.cs
@@ -5,6 +5,8 @@ using TMPro;
 using GameNetcodeStuff;
 
 using MonitorDoorButtons.Utilities;
+using System.Collections.Generic;
+using System.Collections;
 
 namespace MonitorDoorButtons.Patches
 {
@@ -90,6 +92,7 @@ namespace MonitorDoorButtons.Patches
 			MonitorDoorPanel.name = "MonitorDoorPanel";
 			MonitorDoorPanel.localPosition = new Vector3(-0.2f, -1.7f, 0.15f);
 			MonitorDoorPanel.localEulerAngles = new Vector3(90f, 90f, 0f);
+
 			Console.LogInfo($"StartOfRound.CreateMonitorDoorPanel() created: {MonitorDoorPanel.name}");
 
 			//? Get the references for the new buttons
@@ -99,6 +102,34 @@ namespace MonitorDoorButtons.Patches
 				Console.LogError($"StartOfRound.CreateMonitorDoorPanel() could not find MonitorDoorPanel references");
 				return;
 			}
+
+			if (Plugin.GetConfig(1) == true){
+				//GI Compat on
+				//delete the panel
+				ArrayList ignore = ["StartButton","StopButton","Audio"];
+				for (int i=0; i < MonitorDoorPanel.childCount; i++) {
+					GameObject child = MonitorDoorPanel.GetChild(i).gameObject;
+					if(!ignore.Contains(child.name)) {
+						UnityEngine.Object.Destroy(child);
+					}
+				}
+				UnityEngine.Object.Destroy(MonitorDoorPanel.GetComponent<UnityEngine.MeshRenderer>());
+				//fix rotation, position and scale
+
+				MonitorDoorPanel.localRotation = new Quaternion(0.5417f, 0.4545f, -0.4545f, 0.5417f);
+
+				if (Plugin.GetConfig(2) == true) {
+					//bigbuttons true
+					MonitorDoorPanel.transform.localPosition = new Vector3(-0.23f, -1.6f, -0.17f);
+				} else {
+					//bigbuttons null or false
+					MonitorDoorPanel.transform.localPosition = new Vector3(-0.23f, -1.8f, -0.145f);
+					MonitorDoorPanel.transform.localScale = new Vector3(-.75f, -.75f, -.75f);
+					
+				} 
+				
+			}
+
 
 			MonitorStartButtonTrigger = MonitorStartButton.GetComponent<InteractTrigger>();
 			MonitorStopButtonTrigger = MonitorStopButton.GetComponent<InteractTrigger>();

--- a/MonitorDoorButtons/Plugin.cs
+++ b/MonitorDoorButtons/Plugin.cs
@@ -1,10 +1,6 @@
 ﻿using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
-using BepInEx.Configuration;
-using JetBrains.Annotations;
-using System.Runtime.CompilerServices;
-using UnityEngine;
 
 namespace MonitorDoorButtons
 {

--- a/MonitorDoorButtons/Plugin.cs
+++ b/MonitorDoorButtons/Plugin.cs
@@ -1,6 +1,10 @@
 ﻿using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
+using BepInEx.Configuration;
+using JetBrains.Annotations;
+using System.Runtime.CompilerServices;
+using UnityEngine;
 
 namespace MonitorDoorButtons
 {
@@ -10,13 +14,39 @@ namespace MonitorDoorButtons
 		private static readonly Harmony harmony = new Harmony(PluginInfo.PLUGIN_GUID);
 
 		public static ManualLogSource CLog;
+		static bool betterMonitors;
+		static bool biggerButtons;
 
 		private void Awake() {
+
+			//Config
+			var configBetterMonitors = base.Config.Bind(
+				"General",
+				"ButtonsOnMonitor",
+				false,
+				"Moves the buttons onto the monitors above display controls and removes the back panel and power meter; required for GI bettermonitors compatability"
+			);
+			var configBiggerButtons = base.Config.Bind(
+				"General",
+				"BiggerButtons",
+				false,
+				"Makes the monitor buttons bigger, requires ButtonsOnMonitor to be true"
+			);
+
+			betterMonitors = configBetterMonitors.Value;
+			biggerButtons = configBiggerButtons.Value;
+
 			// Plugin startup logic
 			CLog = Logger;
 			CLog.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
 
 			harmony.PatchAll();
 		}
+		public static bool? GetConfig(int index){
+			if (index==1) { return betterMonitors; }
+			if (index==2) { return biggerButtons; }
+			return null;
+		}
+		
 	}
 }


### PR DESCRIPTION
- Added config option to move buttons to monitor for compatability with General Improvements BetterMonitors.

Removes back panel and hydraulic display and moves, rotates and scales buttons to fit on the monitor above the power ones.